### PR TITLE
fix: 修改创建数字人API路由避免308重定向错误

### DIFF
--- a/app/api/v1/endpoints/digital_humans.py
+++ b/app/api/v1/endpoints/digital_humans.py
@@ -19,7 +19,7 @@ def get_digital_human_service(db: Session = Depends(get_db)) -> DigitalHumanServ
     return DigitalHumanService(db)
 
 
-@router.post("/", response_model=SuccessResponse[DigitalHumanResponse], summary="创建数字人")
+@router.post("/create", response_model=SuccessResponse[DigitalHumanResponse], summary="创建数字人")
 async def create_digital_human(
     digital_human_data: DigitalHumanCreate,
     current_user: User = Depends(get_current_active_user),


### PR DESCRIPTION
- 修改创建数字人路由从 @router.post("/") 到 @router.post("/create")
- 统一前后端API路径，避免路径不匹配导致的重定向问题
- 最终路径：POST /api/v1/digital-humans/create

🤖 Generated with [Claude Code](https://claude.ai/code)